### PR TITLE
feat: Add equipment maintenance fund contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 settings/Mainnet.toml
 settings/Testnet.toml
 history.txt
+activate.sh

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,20 +1,22 @@
-
 [project]
 name = "equipment-fund"
 authors = []
+description = ""
 telemetry = false
+requirements = []
+[contracts.equipment-fund]
+path = "contracts/equipment-fund.clar"
+depends_on = []
+
+[repl]
+costs_version = 2
+parser_version = 2
+
 [repl.analysis]
 passes = ["check_checker"]
-[repl.analysis.check_checker]
-# If true, inputs are trusted after tx_sender has been checked.
-trusted_sender = false
-# If true, inputs are trusted after contract-caller has been checked.
-trusted_caller = false
-# If true, untrusted data may be passed into a private function without a
-# warning, if it gets checked inside. This check will also propagate up to the
-# caller.
-callee_filter = false
 
-# [contracts.counter]
-# path = "contracts/counter.clar"
-# depends_on = []
+[repl.analysis.check_checker]
+strict = false
+trusted_sender = false
+trusted_caller = false
+callee_filter = false

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Equipment Maintenance Fund
+
+A smart contract for managing shared equipment maintenance funds. This contract allows:
+
+- Participants to join and contribute to a shared maintenance fund
+- Equipment registration with maintenance costs and intervals
+- Tracking of maintenance schedules and fund balances
+- Performing maintenance and recording expenses
+
+## Features
+
+- Join fund with initial deposit
+- Contribute additional funds
+- Register new equipment (owner only)
+- Track maintenance schedules
+- Perform and record maintenance activities
+- View participant contributions and total fund balance
+
+## Use Cases
+
+- Office equipment maintenance
+- Shared workspace management
+- Community property maintenance
+- Cooperative equipment ownership

--- a/contracts/equipment-fund.clar
+++ b/contracts/equipment-fund.clar
@@ -1,0 +1,83 @@
+;; Equipment Maintenance Fund Contract
+
+;; Constants
+(define-constant contract-owner tx-sender)
+(define-constant err-owner-only (err u100))
+(define-constant err-insufficient-funds (err u101))
+(define-constant err-not-participant (err u102))
+
+;; Data Variables
+(define-map participants principal uint)
+(define-map equipment-items uint {name: (string-ascii 50), maintenance-cost: uint, next-maintenance: uint})
+(define-data-var equipment-count uint u0)
+(define-data-var total-fund uint u0)
+
+;; Private Functions
+(define-private (is-participant (user principal))
+    (default-to false (some (is-some (map-get? participants user))))
+)
+
+;; Public Functions
+(define-public (join-fund (initial-deposit uint))
+    (begin
+        (asserts! (> initial-deposit u0) (err u103))
+        (map-set participants tx-sender initial-deposit)
+        (var-set total-fund (+ (var-get total-fund) initial-deposit))
+        (ok true)
+    )
+)
+
+(define-public (contribute-funds (amount uint))
+    (begin
+        (asserts! (is-participant tx-sender) err-not-participant)
+        (let ((current-contribution (default-to u0 (map-get? participants tx-sender))))
+            (map-set participants tx-sender (+ current-contribution amount))
+            (var-set total-fund (+ (var-get total-fund) amount))
+            (ok true)
+        )
+    )
+)
+
+(define-public (register-equipment (name (string-ascii 50)) (maintenance-cost uint) (maintenance-interval uint))
+    (begin
+        (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+        (let ((equipment-id (var-get equipment-count)))
+            (map-set equipment-items equipment-id 
+                {
+                    name: name,
+                    maintenance-cost: maintenance-cost,
+                    next-maintenance: (+ block-height maintenance-interval)
+                }
+            )
+            (var-set equipment-count (+ equipment-id u1))
+            (ok equipment-id)
+        )
+    )
+)
+
+(define-public (perform-maintenance (equipment-id uint))
+    (begin
+        (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+        (let (
+            (equipment (unwrap! (map-get? equipment-items equipment-id) (err u104)))
+            (maintenance-cost (get maintenance-cost equipment))
+        )
+            (asserts! (>= (var-get total-fund) maintenance-cost) err-insufficient-funds)
+            (var-set total-fund (- (var-get total-fund) maintenance-cost))
+            (ok true)
+        )
+    )
+)
+
+;; Read-only functions
+(define-read-only (get-participant-contribution (user principal))
+    (ok (default-to u0 (map-get? participants user)))
+)
+
+(define-read-only (get-total-fund)
+    (ok (var-get total-fund))
+)
+
+(define-read-only (get-equipment-details (equipment-id uint))
+    (map-get? equipment-items equipment-id)
+)

--- a/tests/.ts
+++ b/tests/.ts
@@ -1,0 +1,75 @@
+import {
+    Clarinet,
+    Tx,
+    Chain,
+    Account,
+    types
+} from 'https://deno.land/x/clarinet@v1.0.0/index.ts';
+import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
+
+Clarinet.test({
+    name: "Can join fund with initial deposit",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const deployer = accounts.get('deployer')!;
+        const wallet1 = accounts.get('wallet_1')!;
+        
+        let block = chain.mineBlock([
+            Tx.contractCall('equipment-fund', 'join-fund', [types.uint(1000)], wallet1.address)
+        ]);
+        
+        block.receipts[0].result.expectOk().expectBool(true);
+        
+        let fundCheck = chain.mineBlock([
+            Tx.contractCall('equipment-fund', 'get-participant-contribution', [types.principal(wallet1.address)], wallet1.address)
+        ]);
+        
+        assertEquals(fundCheck.receipts[0].result.expectOk(), types.uint(1000));
+    }
+});
+
+Clarinet.test({
+    name: "Only owner can register equipment",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const deployer = accounts.get('deployer')!;
+        const wallet1 = accounts.get('wallet_1')!;
+        
+        let block = chain.mineBlock([
+            Tx.contractCall('equipment-fund', 'register-equipment', 
+                [types.ascii("Printer"), types.uint(500), types.uint(100)], 
+                deployer.address
+            ),
+            Tx.contractCall('equipment-fund', 'register-equipment', 
+                [types.ascii("Scanner"), types.uint(300), types.uint(100)], 
+                wallet1.address
+            )
+        ]);
+        
+        block.receipts[0].result.expectOk();
+        block.receipts[1].result.expectErr(types.uint(100)); // err-owner-only
+    }
+});
+
+Clarinet.test({
+    name: "Can perform maintenance with sufficient funds",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const deployer = accounts.get('deployer')!;
+        const wallet1 = accounts.get('wallet_1')!;
+        
+        let block = chain.mineBlock([
+            Tx.contractCall('equipment-fund', 'join-fund', [types.uint(1000)], wallet1.address),
+            Tx.contractCall('equipment-fund', 'register-equipment', 
+                [types.ascii("Printer"), types.uint(500), types.uint(100)], 
+                deployer.address
+            ),
+            Tx.contractCall('equipment-fund', 'perform-maintenance', [types.uint(0)], deployer.address)
+        ]);
+        
+        block.receipts.map(receipt => receipt.result.expectOk());
+        
+        let fundCheck = chain.mineBlock([
+            Tx.contractCall('equipment-fund', 'get-total-fund', [], deployer.address)
+        ]);
+        
+        assertEquals(fundCheck.receipts[0].result.expectOk(), types.uint(500));
+    }
+});

--- a/tests/equipment-fund_test.ts
+++ b/tests/equipment-fund_test.ts
@@ -1,0 +1,26 @@
+
+import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.14.0/index.ts';
+import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
+
+Clarinet.test({
+    name: "Ensure that <...>",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        let block = chain.mineBlock([
+            /* 
+             * Add transactions with: 
+             * Tx.contractCall(...)
+            */
+        ]);
+        assertEquals(block.receipts.length, 0);
+        assertEquals(block.height, 2);
+
+        block = chain.mineBlock([
+            /* 
+             * Add transactions with: 
+             * Tx.contractCall(...)
+            */
+        ]);
+        assertEquals(block.receipts.length, 0);
+        assertEquals(block.height, 3);
+    },
+});


### PR DESCRIPTION
This PR implements an equipment maintenance fund contract that allows:

- Participants to join and contribute to a shared fund
- Equipment registration with maintenance costs
- Maintenance scheduling and tracking
- Fund balance management
- Access control for administrative functions

Changes:
- Added main contract with fund management functions
- Added tests for core functionality
- Added documentation